### PR TITLE
ci: add proper permissions to token

### DIFF
--- a/.github/workflows/publish-javadoc.yaml
+++ b/.github/workflows/publish-javadoc.yaml
@@ -28,6 +28,9 @@ jobs:
           path: target/reports/apidocs
 
   deploy-github-pages:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
A quick fix to add proper permissions to the token. I'll bypass the merge approval exceptionally just to test that this works!